### PR TITLE
Update decode/encode behavior

### DIFF
--- a/base64.hpp
+++ b/base64.hpp
@@ -171,7 +171,7 @@ template <typename RetString>
 inline RetString base64_encode(const unsigned char* bytes_to_encode, size_t in_len, bool url) {
    size_t len_encoded = (in_len + 2) / 3 * 4;
 
-   unsigned char trailing_char = url ? '.' : '=';
+   const unsigned char trailing_char = '=';
 
    //
    // Choose set of base64 characters. They differ
@@ -182,7 +182,7 @@ inline RetString base64_encode(const unsigned char* bytes_to_encode, size_t in_l
    // the correct character set is chosen by subscripting
    // base64_chars with url.
    //
-   const char *base64_chars_ = detail::to_base64_chars[url];
+   const char* base64_chars_ = detail::to_base64_chars[url];
 
    RetString ret;
    ret.reserve(len_encoded);
@@ -202,12 +202,12 @@ inline RetString base64_encode(const unsigned char* bytes_to_encode, size_t in_l
             ret.push_back(base64_chars_[bytes_to_encode[pos + 2] & 0x3f]);
          } else {
             ret.push_back(base64_chars_[(bytes_to_encode[pos + 1] & 0x0f) << 2]);
-            ret.push_back(trailing_char);
+            if (!url) ret.push_back(trailing_char);
          }
       } else {
          ret.push_back(base64_chars_[(bytes_to_encode[pos + 0] & 0x03) << 4]);
-         ret.push_back(trailing_char);
-         ret.push_back(trailing_char);
+         if (!url) ret.push_back(trailing_char);
+         if (!url) ret.push_back(trailing_char);
       }
 
       pos += 3;
@@ -251,12 +251,12 @@ inline RetString decode(const String& encoded_string, bool remove_linebreaks) {
    RetString ret;
    ret.reserve(approx_length_of_decoded_string);
 
-   while (pos < length_of_string) {
+   while (pos < length_of_string && encoded_string.at(pos) != '=') {
       //
       // Iterate over encoded input string in chunks. The size of all
       // chunks except the last one is 4 bytes.
       //
-      // The last chunk might be padded with equal signs or dots
+      // The last chunk might be padded with equal signs
       // in order to make it 4 bytes in size as well, but this
       // is not required as per RFC 2045.
       //
@@ -274,8 +274,7 @@ inline RetString decode(const String& encoded_string, bool remove_linebreaks) {
 
       if ((pos + 2 < length_of_string) &&
           // Check for data that is not padded with equal signs (which is allowed by RFC 2045)
-          encoded_string.at(pos + 2) != '=' &&
-          encoded_string.at(pos + 2) != '.' ) {     // accept URL-safe base 64 strings, too, so check for '.' also.
+          encoded_string.at(pos + 2) != '=') {
          //
          // Emit a chunk's second byte (which might not be produced in the last chunk).
          //
@@ -283,8 +282,7 @@ inline RetString decode(const String& encoded_string, bool remove_linebreaks) {
          ret.push_back(static_cast<typename RetString::value_type>(((pos_of_char_1 & 0x0f) << 4) + ((pos_of_char_2 & 0x3c) >> 2)));
 
          if ((pos + 3 < length_of_string) &&
-             encoded_string.at(pos + 3) != '=' &&
-             encoded_string.at(pos + 3) != '.' ) {
+             encoded_string.at(pos + 3) != '=') {
             //
             // Emit a chunk's third byte (which might not be produced in the last chunk).
             //

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -48,16 +48,19 @@ int main() {
      auto input = "YWJjMTIzJCYoKSc/tPUB+n5h========="s;
      auto expected_output = "abc123$&()'?\xb4\xf5\x01\xfa~a"s;
 
-     try {
-       base64_decode(input);
-       CHECK(false);
-     } catch(const std::exception&) {}
+     CHECK(expected_output == base64_decode(input));
   }
   {
-     auto input = "YWJjMTIzJCYoKSc/tPU$B+n5h="s;
+     auto input = "YWJjMTIzJCYoKSc/tPUB+n5h="s;
+     auto expected_output = "abc123$&()'?\xb4\xf5\x01\xfa~a"s;
+
+     CHECK(expected_output == base64_decode(input));
+  }
+  {
+     auto input = "YWJjMTIzJCYoKSc/tPU$B+n5h="s; // $ in input
      try {
-       base64_decode(input);
-       CHECK(false);
+        base64_decode(input);
+        CHECK(false);
      } catch(const std::exception&) {}
   }
 
@@ -123,7 +126,7 @@ int main() {
    std::string a17_encoded_url = base64_encode(a17_orig, true);
 
    CHECK(a17_encoded == "YWFhYWFhYWFhYWFhYWFhYWE=");
-   CHECK(a17_encoded_url == "YWFhYWFhYWFhYWFhYWFhYWE.");
+   CHECK(a17_encoded_url == "YWFhYWFhYWFhYWFhYWFhYWE");
    CHECK(base64_decode(a17_encoded_url) == a17_orig);
    CHECK(base64_decode(a17_encoded) == a17_orig);
 
@@ -137,7 +140,7 @@ int main() {
    std::string s_6364_encoded_url = base64_encode(s_6364, true);
 
    CHECK(s_6364_encoded == "A+//+Q==");
-   CHECK(s_6364_encoded_url == "A-__-Q..");
+   CHECK(s_6364_encoded_url == "A-__-Q");
    CHECK(base64_decode(s_6364_encoded) == s_6364);
    CHECK(base64_decode(s_6364_encoded_url) == s_6364);
 


### PR DESCRIPTION
- Remove `.` as a padding character as the spec does not allow it.
  - See https://datatracker.ietf.org/doc/html/rfc4648#section-5
- Allow extra `=` padding character to be more forgiving of input.
  - See no reason to fail a decode because of extra `=`
- Do not pad output for `url` format.